### PR TITLE
chore: fixed permission issues for GitHub workflows

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,6 +16,9 @@ on:
         description: "The next version bump"
         value: ${{ jobs.changelog.outputs.version }}
 
+permissions:
+  contents: write
+
 jobs:
   changelog:
     name: Generate changelog

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   changelog:
     name: Changelog
@@ -48,7 +51,7 @@ jobs:
 
   compile:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: Compile VAPID Key Generator Binary
+    name: VAPID Key Generator
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -123,6 +126,7 @@ jobs:
           overwrite: true
           path: ${{ steps.compile.outputs.filename }}
           retention-days: 1
+          compression-level: 0
 
   release:
     name: Release


### PR DESCRIPTION
This PR fixes the permission issues, which prevented an automatic push of the updated `CHANGELOG.md` in the `changelog.yml` workflow.