### PR TITLE
chore: fixed adding CHANGELOG.md to tag, added artifacts to release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,8 +5,6 @@ on:
     inputs:
       args:
         type: string
-      commit:
-        type: boolean
 
     outputs:
       content:
@@ -15,9 +13,6 @@ on:
       version:
         description: "The next version bump"
         value: ${{ jobs.changelog.outputs.version }}
-
-permissions:
-  contents: write
 
 jobs:
   changelog:
@@ -50,14 +45,3 @@ jobs:
         with:
           config: ./cliff.toml
           args: ${{ inputs.args }}
-
-      - name: Commit CHANGELOG.md
-        id: commit
-        if: ${{ inputs.commit }}
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          set +e
-          git add CHANGELOG.md
-          git commit -m "Update CHANGELOG.md [skip ci]"
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
           context_flag="--context=production"
           alias_flag=""
 
-          if [ ${{ github.event.pull_request.state == 'open'}} ]; then
+          if ${{ github.event.pull_request.state == 'open' }}; then
             prod_flag=""
             context_flag="--context=deploy_preview"
             alias_flag="--alias=${{ needs.outputs.outputs.short_sha }}"
@@ -159,7 +159,7 @@ jobs:
           prod_flag="--prod"
           target_flag="--target=production"
 
-          if [ ${{ github.event.pull_request.state == 'open'}} ]; then
+          if ${{ github.event.pull_request.state == 'open' }}; then
             prod_flag=""
             target_flag="--target=preview"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
     uses: ./.github/workflows/changelog.yml
     with:
       args: -v --bump
-      commit: true
 
   tag:
     name: Tag
@@ -27,7 +26,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Create tag
+      - name: Commit CHANGELOG.md
+        id: commit
+        run: |
+          echo "${{ needs.changelog.outputs.content }}" > CHANGELOG.md
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          set +e
+          git add CHANGELOG.md
+          git commit -m "Update CHANGELOG.md [skip ci]"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${GITHUB_REPOSITORY}.git main
+
+      - name: Create Tag
         id: tag
         uses: actions/github-script@v7
         with:
@@ -46,7 +57,7 @@ jobs:
 
     uses: ./.github/workflows/changelog.yml
     with:
-      args: -v --latest --strip header
+      args: -v --latest --strip all
       commit: false
 
   compile:
@@ -137,6 +148,7 @@ jobs:
 
     steps:
       - name: Download Artifacts
+        id: download
         uses: actions/download-artifact@v4
 
       - name: Release
@@ -144,5 +156,6 @@ jobs:
         with:
           body: ${{ needs.changes.outputs.content }}
           tag_name: ${{ needs.changes.outputs.version }}
+          fail_on_unmatched_files: true
           files: |
-            vapid-keygen_*
+            ${{ steps.download.outputs.download-path }}/*/vapid-keygen_*

--- a/go.mod
+++ b/go.mod
@@ -85,9 +85,6 @@ require (
 	mellium.im/sasl v0.3.2 // indirect
 )
 
-require (
-	github.com/saschazar21/go-web-push-server v0.0.0-unpublished
-	github.com/vercel/go-bridge v0.0.0-20221108222652-296f4c6bdb6d
-)
+require github.com/saschazar21/go-web-push-server v0.0.0-unpublished
 
 replace github.com/saschazar21/go-web-push-server => ./

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ github.com/uptrace/bun/driver/pgdriver v1.2.5 h1:+0Ofdg/tW7DsIXdTizYWapSex6Csh9V
 github.com/uptrace/bun/driver/pgdriver v1.2.5/go.mod h1:RsYV08Z72glum3swBhag7IBl1D+eztjWmodfcOZFHJ0=
 github.com/uptrace/bun/extra/bundebug v1.2.5 h1:DsI/gl4jvq5tQ84yPqnlRYIQ4U6AouTqxJ8Y5Oijfz4=
 github.com/uptrace/bun/extra/bundebug v1.2.5/go.mod h1:JFeYvklf5p92ZILXx4siMe2tEVn5JLelww3IGcJb4yA=
-github.com/vercel/go-bridge v0.0.0-20221108222652-296f4c6bdb6d h1:yF16FifsUK1ZfRAiG8c3Sm2hM7PaJGtBduL3BzI7ZE4=
-github.com/vercel/go-bridge v0.0.0-20221108222652-296f4c6bdb6d/go.mod h1:RTTykQS0l8RDfOjATEreOpvPDo/yn1zW2nCCP8zBM7E=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=


### PR DESCRIPTION
This PR adds the previously missing `CHANGELOG.md` to the git tag.

Furthermore, the `glob` pattern for the compiled artifacts has been fixed, as well as the condition to check, whether a production deployment is triggered for Netlify & Vercel.