### PR TITLE
chore: removed v-prefix, added tag-pattern parameter

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       content: ${{ steps.changelog.outputs.content }}
-      version: v${{ steps.changelog.outputs.version }}
+      version: ${{ steps.changelog.outputs.version }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     uses: ./.github/workflows/changelog.yml
     with:
-      args: -v --bump --tag-pattern="v[0.9].*"
+      args: -v --bump --tag-pattern="v[0-9].*"
 
   tag:
     name: Tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     uses: ./.github/workflows/changelog.yml
     with:
-      args: -v --bump
+      args: -v --bump --tag-pattern="v[0.9].*"
 
   tag:
     name: Tag


### PR DESCRIPTION
This PR fixes the hack, where a `v`-prefix was added to the output of the `changelog.yml` workflow.

Instead, the prefix is ensured via the `--tag-pattern` parameter when calling `git-cliff`.