### PR TITLE
fix: fixed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,16 +46,24 @@ jobs:
 
           sed -i 's|require github.com/${{ github.repository }} v[0-9.]*[-a-zA-Z0-9]*|require github.com/${{ github.repository }} ${{ needs.changelog.outputs.version }}|g' go.mod
           git add go.mod go.sum
-          git commit -m "Update go.mod go.sum [skip ci]"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to go.mod/go.sum, skipping commit."
+          else
+            git commit -m "Update go.mod go.sum [skip ci]"
+            git push
+          fi
 
       - name: Commit CHANGELOG.md
         run: |
           echo "${{ needs.changelog.outputs.content }}" > CHANGELOG.md
 
           git add CHANGELOG.md
-          git commit -m "Update CHANGELOG.md [skip ci]"
-          git push
+          if git diff --cached --quiet; then
+            echo "No changes to CHANGELOG.md, skipping commit."
+          else
+            git commit -m "Update CHANGELOG.md [skip ci]"
+            git push
+          fi
 
       - name: Create Tag
         id: tag


### PR DESCRIPTION
This PR adds a `git commit` guard, which prevents the workflow from failing whenever there are no changes to committed.